### PR TITLE
Fix race in Unix test

### DIFF
--- a/reap_unix_test.go
+++ b/reap_unix_test.go
@@ -36,6 +36,8 @@ func TestReap_ReapChildren(t *testing.T) {
 		if err := cmd.Start(); err != nil {
 			t.Fatalf("err: %v", err)
 		}
+		
+		time.Sleep(1 * time.Second)
 
 		childPid := cmd.Process.Pid
 		if err := cmd.Process.Kill(); err != nil {


### PR DESCRIPTION
Hi there.  My POSIX process and signal handling is a bit rusty but I've been trying to fix a bug/race in the Unix test.  This patch fixes it, but I'm at a loss to explain why.  )-:

Without the patch the test nearly always hits the "should have reaped %d" timeout in the select() statement at the bottom of the killAndCheck function.  I have seen it pass exactly once though...
